### PR TITLE
Support nested test style spec

### DIFF
--- a/kotest-extensions-android/kotest-extensions-android-tests/build.gradle.kts
+++ b/kotest-extensions-android/kotest-extensions-android-tests/build.gradle.kts
@@ -39,7 +39,7 @@ android {
 dependencies {
   implementation("androidx.test:core-ktx:1.5.0")
   testImplementation(project(":kotest-extensions-android"))
-  testImplementation("io.kotest:kotest-runner-junit5:5.8.0")
+  testImplementation("io.kotest:kotest-runner-junit5:5.9.0")
   androidTestImplementation("androidx.test:runner:1.5.2")
   androidTestImplementation("androidx.test:core:1.5.0")
   androidTestImplementation("androidx.test:rules:1.5.0")

--- a/kotest-extensions-android/kotest-extensions-android-tests/src/test/kotlin/br/com/colman/kotest/android/extensions/ContainedRobolectricTest.kt
+++ b/kotest-extensions-android/kotest-extensions-android-tests/src/test/kotlin/br/com/colman/kotest/android/extensions/ContainedRobolectricTest.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import br.com.colman.kotest.TestApplication
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -65,3 +66,20 @@ abstract class ContainedRobolectricRunnerMergeOverwriteTest : StringSpec({
 @Suppress("ClassName")
 @RobolectricTest(sdk = Build.VERSION_CODES.O_MR1)
 class ContainedRobolectricRunnerMergeOverwriteO_MR1Test : ContainedRobolectricRunnerMergeOverwriteTest()
+
+@RobolectricTest
+class ContainedRobolectricRunnerDefaultApplicationBehaviorSpecTest : BehaviorSpec({
+  Context("Get the Application defined in AndroidManifest.xml") {
+    Given("A application context") {
+      val applicationContext = ApplicationProvider.getApplicationContext<Application>()
+
+      When("Get class from application context") {
+        val applicationClass = applicationContext::class
+
+        Then("It should be TestApplication") {
+          applicationClass shouldBe TestApplication::class
+        }
+      }
+    }
+  }
+})


### PR DESCRIPTION
If I use any nested test style spec like BehaviorSpec, the test will not proceed.
I think the problem is 'runBlocking'.
So I change some codes. But I used reflection to get runner's thread ExecutorService.
If you have any other good idea, please let me know.