### PR TITLE
Remove robolectric deprecated override

### DIFF
--- a/kotest-extensions-android/build.gradle.kts
+++ b/kotest-extensions-android/build.gradle.kts
@@ -44,7 +44,7 @@ configurations {
 dependencies {
   implementation(kotlin("reflect"))
   implementation("io.kotest:kotest-framework-api:5.9.0")
-  implementation("org.robolectric:robolectric:4.11.1")
+  implementation("org.robolectric:robolectric:4.12.2")
   implementation("junit:junit:4.13.2")
   implementation("androidx.appcompat:appcompat:1.7.0")
 

--- a/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/Extensions.kt
+++ b/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/Extensions.kt
@@ -1,0 +1,9 @@
+package br.com.colman.kotest.android.extensions.robolectric
+
+import java.lang.reflect.Field
+import java.lang.reflect.Type
+
+internal fun Class<*>.getField(fieldClass: Type): Field {
+  return declaredFields.firstOrNull { it.type == fieldClass }
+    ?: throw IllegalStateException("Not found $fieldClass field.")
+}

--- a/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/Extensions.kt
+++ b/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/Extensions.kt
@@ -7,3 +7,9 @@ internal fun Class<*>.getField(fieldClass: Type): Field {
   return declaredFields.firstOrNull { it.type == fieldClass }
     ?: throw IllegalStateException("Not found $fieldClass field.")
 }
+
+internal inline fun <reified T> Class<*>.getValue(obj: Any): T {
+  val field = getField(T::class.java)
+  field.isAccessible = true
+  return field.get(obj) as T
+}

--- a/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/RobolectricExtension.kt
+++ b/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/RobolectricExtension.kt
@@ -115,7 +115,9 @@ class RobolectricExtension : ConstructorExtension, TestCaseExtension {
     val containedRobolectricRunner = runnerMap[testCase.spec]!!
     // Using sdkEnvironment.executorService to ensure Robolectric's
     // looper state doesn't carry over to the next test class.
-    val executorService = containedRobolectricRunner.sdkEnvironment.getExecutorService()
+    val executorService =
+      Sandbox::class.java
+        .getValue<ExecutorService>(containedRobolectricRunner.sdkEnvironment)
     return withContext(executorService.asCoroutineDispatcher()) {
       if (testCase.isRootTest()) {
         containedRobolectricRunner.containedBefore()
@@ -127,14 +129,6 @@ class RobolectricExtension : ConstructorExtension, TestCaseExtension {
       result
     }
   }
-}
-
-private fun Sandbox.getExecutorService(): ExecutorService {
-  val field = Sandbox::class.java.declaredFields
-    .firstOrNull { it.type == ExecutorService::class.java }
-  checkNotNull(field) { "Not found ExecutorService field." }
-  field.isAccessible = true
-  return field.get(this) as ExecutorService
 }
 
 internal class KotestDefaultApplication : Application()


### PR DESCRIPTION
Robolectric evaluates Config by the following sequence.
```
Robolectric.getChildren() -> Robolectric.getConfiguration() -> HierarchicalConfigurationStrategy.getConfig()
```

I tried some ways to resolve #5 but didn't find way to override them properly without reflection.