### PR TITLE
Fix not working Robolectric tests with kotest-extensions-android dependency

### DIFF
--- a/kotest-extensions-android/kotest-extensions-android-tests/build.gradle.kts
+++ b/kotest-extensions-android/kotest-extensions-android-tests/build.gradle.kts
@@ -41,6 +41,8 @@ dependencies {
   testImplementation(project(":kotest-extensions-android"))
   testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
   testImplementation("org.robolectric:robolectric:4.12.2")
+  testImplementation("androidx.test.espresso:espresso-core:3.6.1")
+  testImplementation("org.junit.vintage:junit-vintage-engine:5.11.3")
   androidTestImplementation("androidx.test:runner:1.5.2")
   androidTestImplementation("androidx.test:core:1.5.0")
   androidTestImplementation("androidx.test:rules:1.5.0")

--- a/kotest-extensions-android/kotest-extensions-android-tests/src/test/kotlin/br/com/colman/kotest/android/extensions/NoKotestRobolectricTest.kt
+++ b/kotest-extensions-android/kotest-extensions-android-tests/src/test/kotlin/br/com/colman/kotest/android/extensions/NoKotestRobolectricTest.kt
@@ -1,0 +1,25 @@
+package br.com.colman.kotest.android.extensions
+
+import androidx.test.core.app.ActivityScenario.launch
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import br.com.colman.kotest.R
+import br.com.colman.kotest.TestActivity
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NoKotestRobolectricTest {
+  @Test
+  fun `TextView in TestActivity has Hello World!`() {
+    launch(TestActivity::class.java)
+
+    onView(withId(R.id.textView))
+      .check(matches(isDisplayed()))
+      .check(matches(withText("Hello World!")))
+  }
+}

--- a/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/ContainedRobolectricRunner.kt
+++ b/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/ContainedRobolectricRunner.kt
@@ -6,6 +6,7 @@ import org.junit.runners.model.FrameworkMethod
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.internal.bytecode.InstrumentationConfiguration
+import org.robolectric.pluginapi.config.ConfigurationStrategy
 import org.robolectric.pluginapi.config.Configurer
 import org.robolectric.plugins.HierarchicalConfigurationStrategy
 import org.robolectric.util.inject.Injector
@@ -65,7 +66,10 @@ internal class ContainedRobolectricRunner(
 
   companion object {
     private fun kotestInjector(config: Config): Injector {
-      val defaultInjector = defaultInjector().bind(Config::class.java, config).build()
+      val defaultInjector = defaultInjector()
+        .bind(Config::class.java, config)
+        .bind(ConfigurationStrategy::class.java, KotestHierarchicalConfigurationStrategy::class.java)
+        .build()
       return Injector.Builder(defaultInjector, ContainedRobolectricRunner::class.java.classLoader)
         .build()
     }

--- a/kotest-extensions-android/src/main/resources/META-INF/services/org.robolectric.pluginapi.config.ConfigurationStrategy
+++ b/kotest-extensions-android/src/main/resources/META-INF/services/org.robolectric.pluginapi.config.ConfigurationStrategy
@@ -1,1 +1,0 @@
-br.com.colman.kotest.android.extensions.robolectric.ContainedRobolectricRunner$KotestHierarchicalConfigurationStrategy


### PR DESCRIPTION
KotestHierarchicalConfigurationStrategy injection is changed from ServiceLoader to Injector bind for resolving #29.