### PR TITLE
Update to Kotest 6.0.0.M4 + Kotlin 2.1.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  kotlin("jvm") version "1.8.20" apply false
-  kotlin("android") version "1.8.20" apply false
+  kotlin("jvm") version "2.1.20" apply false
+  kotlin("android") version "2.1.20" apply false
   id("com.android.application") version "7.4.2" apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,5 @@
 kotlin.code.style=official
 android.useAndroidX=true
+
+org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=756m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+systemProp.org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=756m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/kotest-assertions-android/build.gradle.kts
+++ b/kotest-assertions-android/build.gradle.kts
@@ -4,12 +4,16 @@ plugins {
   kotlin("android")
   kotlin("kapt")
   id("com.android.library")
-  id("org.jetbrains.dokka") version "1.8.10"
+  id("org.jetbrains.dokka") version "1.9.10"
   `maven-publish`
   signing
 }
 
+
+kotlin { jvmToolchain(11) }
+
 android {
+  namespace = "br.com.colman.kotest.assertions"
   compileSdk = 33
   defaultConfig {
     minSdk = 21
@@ -17,6 +21,7 @@ android {
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
+
   buildTypes {
     getByName("release") {
       isMinifyEnabled = false
@@ -27,6 +32,7 @@ android {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
   }
+  kotlinOptions { jvmTarget = "11"}
 
   packagingOptions {
     exclude("META-INF/AL2.0")
@@ -43,7 +49,7 @@ configurations {
 
 dependencies {
   implementation("androidx.core:core-ktx:1.10.0")
-  implementation("io.kotest:kotest-assertions-core:5.9.1")
+  implementation("io.kotest:kotest-assertions-core:6.0.0.M4")
 
   androidTestImplementation(project(":kotest-runner-android"))
   androidTestImplementation("androidx.test:runner:1.5.2")
@@ -115,8 +121,6 @@ publishing {
 }
 
 tasks.named("dokkaHtml").dependsOn("kaptReleaseKotlin")
-
-
 
 val signingKey: String? by project
 val signingPassword: String? by project

--- a/kotest-assertions-android/src/androidTest/kotlin/br/com/colman/kotest/android/matchers/view/ViewMatchersTests.kt
+++ b/kotest-assertions-android/src/androidTest/kotlin/br/com/colman/kotest/android/matchers/view/ViewMatchersTests.kt
@@ -1,2 +1,0 @@
-package br.com.colman.kotest.android.matchers.view
-

--- a/kotest-assertions-android/src/main/AndroidManifest.xml
+++ b/kotest-assertions-android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
-<manifest package="br.com.colman.kotest.assertions">
+<manifest>
 
 </manifest>

--- a/kotest-assertions-android/src/main/kotlin/br/com/colman/kotest/android/matchers/textview/matchers.kt
+++ b/kotest-assertions-android/src/main/kotlin/br/com/colman/kotest/android/matchers/textview/matchers.kt
@@ -18,8 +18,8 @@ infix fun TextView.shouldNotHaveText(text: String) = this shouldNot haveText(tex
 fun haveText(text: String) = object : Matcher<TextView> {
   override fun test(value: TextView) = MatcherResult(
     text.contentEquals(value.text),
-    "TextView should have text $text but was ${value.text}",
-    "TextView should not have text $text, but had"
+    { "TextView should have text $text but was ${value.text}" },
+    { "TextView should not have text $text, but had" }
   )
 
 }
@@ -32,8 +32,8 @@ fun haveTextColorId(@ColorRes colorRes: Int, theme: Theme? = null) = object: Mat
 
     return MatcherResult(
       resourceColor == currentColor,
-      "TextView should have color resource $resourceName(#$resourceColor) but was #$currentColor",
-      "TextView should not have color $resourceName(#$resourceColor), but had"
+      { "TextView should have color resource $resourceName(#$resourceColor) but was #$currentColor" },
+      { "TextView should not have color $resourceName(#$resourceColor), but had" }
     )
   }
 }
@@ -55,8 +55,8 @@ fun haveTextColor(@ColorInt color: Int) = object: Matcher<TextView> {
 
     return MatcherResult(
       color == currentColor,
-      "TextView should have color $color but was $currentColor",
-      "TextView should not have color $color, but had"
+      { "TextView should have color $color but was $currentColor" },
+      { "TextView should not have color $color, but had" }
     )
   }
 }
@@ -71,7 +71,7 @@ fun TextView.shouldNotBeAllCaps() = this shouldNot beAllCaps()
 fun beAllCaps() = object : Matcher<TextView> {
   override fun test(value: TextView) = MatcherResult(
     value.isAllCaps,
-    "TextView should have AllCaps as transformation method",
-    "TextView should not have AllCaps as transformation method"
+    { "TextView should have AllCaps as transformation method" },
+    { "TextView should not have AllCaps as transformation method" }
   )
 }

--- a/kotest-assertions-android/src/main/kotlin/br/com/colman/kotest/android/matchers/view/matchers.kt
+++ b/kotest-assertions-android/src/main/kotlin/br/com/colman/kotest/android/matchers/view/matchers.kt
@@ -12,8 +12,8 @@ fun View.shouldNotBeVisible() = this shouldNot beVisible()
 fun beVisible() = object : Matcher<View> {
   override fun test(value: View) = MatcherResult(
     value.visibility == View.VISIBLE,
-    "View should be VISIBLE but was ${value.visibilityAsString()}",
-    "View should not be VISIBLE, but was"
+    { "View should be VISIBLE but was ${value.visibilityAsString()}" },
+    { "View should not be VISIBLE, but was" }
   )
 }
 
@@ -23,8 +23,8 @@ fun View.shouldNotBeInvisible() = this shouldNot beInvisible()
 fun beInvisible() = object : Matcher<View> {
   override fun test(value: View) = MatcherResult(
     value.visibility == View.INVISIBLE,
-    "View should be INVISIBLE, but was ${value.visibilityAsString()}",
-    "View should not be INVISIBLE, but was"
+    { "View should be INVISIBLE, but was ${value.visibilityAsString()}" },
+    { "View should not be INVISIBLE, but was" }
   )
 }
 
@@ -34,8 +34,8 @@ fun View.shouldNotBeGone() = this shouldNot beGone()
 fun beGone() = object : Matcher<View> {
   override fun test(value: View) = MatcherResult(
     value.visibility == View.GONE,
-    "View should be GONE, but was ${value.visibilityAsString()}",
-    "View should not be GONE, but was"
+    { "View should be GONE, but was ${value.visibilityAsString()}" },
+    { "View should not be GONE, but was" }
   )
 
 }
@@ -54,8 +54,8 @@ fun View.shouldNotHaveContentDescription() = this shouldNot haveContentDescripti
 fun haveContentDescription() = object : Matcher<View> {
   override fun test(value: View) = MatcherResult(
     value.contentDescription != null && value.contentDescription.isNotBlank(),
-    "View should have ContentDescription, but had none",
-    "View should not have ContentDescription, but had ${value.contentDescription}"
+    { "View should have ContentDescription, but had none" },
+    { "View should not have ContentDescription, but had ${value.contentDescription}" }
   )
 }
 
@@ -65,8 +65,8 @@ infix fun View.shouldNotHaveContentDescription(contentDescription: String) = thi
 fun haveContentDescription(contentDescription: String) = object : Matcher<View> {
   override fun test(value: View) = MatcherResult(
     contentDescription.contentEquals(value.contentDescription),
-    "View should have ContentDescription $contentDescription, but was ${value.contentDescription}",
-    "View should not have ContentDescription $contentDescription, but had"
+    { "View should have ContentDescription $contentDescription, but was ${value.contentDescription}" },
+    { "View should not have ContentDescription $contentDescription, but had" }
   )
 }
 
@@ -78,8 +78,8 @@ fun View.shouldNotHaveTag(key: Int, value: Any) = this shouldNot haveTag(key, va
 fun haveTag(key: Int, tagValue: Any) = object : Matcher<View> {
   override fun test(value: View) = MatcherResult(
     value.getTag(key) == tagValue,
-    "View should have tag with Key $key and value $tagValue, but value was $tagValue",
-    "View should not have tag with Key $key and value $tagValue, but had"
+    { "View should have tag with Key $key and value $tagValue, but value was $tagValue" },
+    { "View should not have tag with Key $key and value $tagValue, but had" }
   )
 }
 
@@ -89,8 +89,8 @@ infix fun View.shouldNotHaveTag(value: Any) = this shouldNot haveTag(value)
 fun haveTag(tagValue: Any) = object : Matcher<View> {
   override fun test(value: View) = MatcherResult(
     value.tag == tagValue,
-    "View should have tag with value $tagValue, but was ${value.tag}",
-    "View should not have tag with value $tagValue, but had"
+    { "View should have tag with value $tagValue, but was ${value.tag}" },
+    { "View should not have tag with value $tagValue, but had" }
   )
 }
 
@@ -100,8 +100,8 @@ fun View.shouldNotBeEnabled() = this shouldNot beEnabled()
 fun beEnabled() = object : Matcher<View> {
   override fun test(value: View) = MatcherResult(
     value.isEnabled,
-    "View should be enabled, but isn't",
-    "View should not be enabled, but is"
+    { "View should be enabled, but isn't" },
+    { "View should not be enabled, but is" }
   )
 }
 
@@ -111,8 +111,8 @@ fun View.shouldNotBeFocused() = this shouldNot beFocused()
 fun beFocused() = object : Matcher<View> {
   override fun test(value: View) = MatcherResult(
     value.isFocused,
-    "View should be focused, but isn't",
-    "View should not be focused, but is"
+    { "View should be focused, but isn't" },
+    { "View should not be focused, but is" }
   )
 }
 
@@ -122,8 +122,8 @@ fun View.shouldNotBeFocusable() = this shouldNot beFocusable()
 fun beFocusable() = object : Matcher<View> {
   override fun test(value: View) = MatcherResult(
     value.isFocusable,
-    "View should be focusable, but isn't",
-    "View should not be focusable, but is"
+    { "View should be focusable, but isn't" },
+    { "View should not be focusable, but is" }
   )
 }
 
@@ -133,8 +133,8 @@ fun View.shouldNotBeFocusableInTouchMode() = this shouldNot beFocusableInTouchMo
 fun beFocusableInTouchMode() = object : Matcher<View> {
   override fun test(value: View) = MatcherResult(
     value.isFocusableInTouchMode,
-    "View should be focusable in touch mode, but isn't",
-    "View should not be focusable in touch mode, but is"
+    { "View should be focusable in touch mode, but isn't" },
+    { "View should not be focusable in touch mode, but is" }
   )
 }
 
@@ -144,8 +144,8 @@ fun View.shouldNotBeClickable() = this shouldNot beClickable()
 fun beClickable() = object : Matcher<View> {
   override fun test(value: View) = MatcherResult(
     value.isClickable,
-    "View should be clickable, but isn't",
-    "View should not be clickable, but is"
+    { "View should be clickable, but isn't" },
+    { "View should not be clickable, but is" }
   )
 }
 
@@ -155,7 +155,7 @@ fun View.shouldNotBeLongClickable() = this shouldNot beLongClickable()
 fun beLongClickable() = object : Matcher<View> {
   override fun test(value: View) = MatcherResult(
     value.isLongClickable,
-    "View should be long clickable, but isn't",
-    "View should not be long clickable, but is"
+    { "View should be long clickable, but isn't" },
+    { "View should not be long clickable, but is" }
   )
 }

--- a/kotest-extensions-android/build.gradle.kts
+++ b/kotest-extensions-android/build.gradle.kts
@@ -4,12 +4,15 @@ plugins {
   kotlin("android")
   kotlin("kapt")
   id("com.android.library")
-  id("org.jetbrains.dokka") version "1.8.10"
+  id("org.jetbrains.dokka") version "1.9.10"
   `maven-publish`
   signing
 }
 
+kotlin { jvmToolchain(11) }
+
 android {
+  namespace = "br.com.colman.kotest.extensions"
   compileSdk = 33
   defaultConfig {
     minSdk = 21
@@ -17,16 +20,19 @@ android {
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
+
   buildTypes {
     getByName("release") {
       isMinifyEnabled = false
     }
   }
 
+
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
   }
+  kotlinOptions { jvmTarget = "11"}
 
   packagingOptions {
     exclude("META-INF/AL2.0")
@@ -43,7 +49,7 @@ configurations {
 
 dependencies {
   implementation(kotlin("reflect"))
-  implementation("io.kotest:kotest-framework-api:5.9.1")
+  implementation("io.kotest:kotest-framework-engine:6.0.0.M4")
   implementation("org.robolectric:robolectric:4.12.2")
   implementation("junit:junit:4.13.2")
   implementation("androidx.appcompat:appcompat:1.7.0")

--- a/kotest-extensions-android/kotest-extensions-android-tests/build.gradle.kts
+++ b/kotest-extensions-android/kotest-extensions-android-tests/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
   kotlin("android")
 }
 
+kotlin { jvmToolchain(11) }
+
 android {
   namespace = "br.com.colman.kotest"
   compileSdk = 33
@@ -16,6 +18,11 @@ android {
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
+  publishing {
+    singleVariant("release") {
+      withSourcesJar()
+    }
+  }
 
   packagingOptions {
     exclude("META-INF/**")
@@ -27,6 +34,7 @@ android {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
   }
+  kotlinOptions { jvmTarget = "11"}
 
   testOptions {
     unitTests {

--- a/kotest-extensions-android/src/main/AndroidManifest.xml
+++ b/kotest-extensions-android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
-<manifest package="br.com.colman.kotest.extensions">
+<manifest>
 
 </manifest>

--- a/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/RobolectricExtension.kt
+++ b/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/RobolectricExtension.kt
@@ -1,9 +1,9 @@
 package br.com.colman.kotest.android.extensions.robolectric
 
 import android.app.Application
+import io.kotest.core.config.AbstractPackageConfig
 import io.kotest.core.extensions.ConstructorExtension
 import io.kotest.core.extensions.TestCaseExtension
-import io.kotest.core.spec.AutoScan
 import io.kotest.core.spec.Spec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
@@ -14,12 +14,15 @@ import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
 import kotlin.time.Duration
 
+class RoboElectricConfig: AbstractPackageConfig() {
+  override val extensions = listOf(RobolectricExtension())
+}
+
 /**
  * We override TestCaseExtension to configure the Robolectric environment because TestCase intercept
  * occurs on the same thread the test is run.  This is unfortunate because it is run for every test,
  * rather than every spec. But the SpecExtension intercept is run on a different thread.
  */
-@AutoScan
 class RobolectricExtension : ConstructorExtension, TestCaseExtension {
 
   private val runnerMap = WeakHashMap<Spec, ContainedRobolectricRunner>()

--- a/kotest-runner-android/build.gradle.kts
+++ b/kotest-runner-android/build.gradle.kts
@@ -1,14 +1,16 @@
 plugins {
   kotlin("jvm")
-  id("org.jetbrains.dokka") version "1.8.10"
+  id("org.jetbrains.dokka") version "1.9.10"
   `maven-publish`
   signing
 }
 
+kotlin { jvmToolchain(11) }
+
 dependencies {
   api("junit:junit:4.13.2")
-  api("io.kotest:kotest-framework-engine:5.9.0")
-  api("io.kotest:kotest-framework-discovery:5.9.1")
+  api("io.kotest:kotest-framework-engine:6.0.0.M4")
+  api("io.kotest:kotest-assertions-core:6.0.0.M4")
 }
 
 val sourcesJar by tasks.registering(Jar::class) {

--- a/kotest-runner-android/kotest-runner-android-tests/build.gradle.kts
+++ b/kotest-runner-android/kotest-runner-android-tests/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
   kotlin("android")
 }
 
+kotlin { jvmToolchain(11) }
+
 android {
   namespace = "br.com.colman.kotest"
   compileSdk = 33
@@ -27,6 +29,7 @@ android {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
   }
+  kotlinOptions { jvmTarget = "11"}
 }
 
 

--- a/kotest-runner-android/src/main/kotlin/br/com/colman/kotest/JUnitTestEngineListener.kt
+++ b/kotest-runner-android/src/main/kotlin/br/com/colman/kotest/JUnitTestEngineListener.kt
@@ -1,6 +1,5 @@
 package br.com.colman.kotest
 
-import io.kotest.core.config.ProjectConfiguration
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.engine.listener.AbstractTestEngineListener
@@ -14,7 +13,7 @@ class JUnitTestEngineListener(
    private val notifier: RunNotifier,
 ) : AbstractTestEngineListener() {
 
-   private val formatter = DefaultDisplayNameFormatter(ProjectConfiguration())
+   private val formatter = DefaultDisplayNameFormatter()
 
    override suspend fun testStarted(testCase: TestCase) {
       notifier.fireTestStarted(describeTestCase(testCase, formatter.format(testCase)))

--- a/kotest-runner-android/src/main/kotlin/br/com/colman/kotest/KotestRunnerAndroid.kt
+++ b/kotest-runner-android/src/main/kotlin/br/com/colman/kotest/KotestRunnerAndroid.kt
@@ -1,11 +1,13 @@
 package br.com.colman.kotest
 
-import io.kotest.core.config.EmptyExtensionRegistry
-import io.kotest.core.config.ProjectConfiguration
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.names.DuplicateTestNameMode
+import io.kotest.engine.extensions.EmptyExtensionRegistry
 import io.kotest.core.spec.Spec
 import io.kotest.engine.TestEngineLauncher
+import io.kotest.engine.config.ProjectConfigResolver
 import io.kotest.engine.spec.Materializer
-import io.kotest.engine.spec.createAndInitializeSpec
+import io.kotest.engine.spec.SpecInstantiator
 import io.kotest.engine.test.names.DefaultDisplayNameFormatter
 import kotlinx.coroutines.runBlocking
 import org.junit.runner.Description
@@ -15,7 +17,7 @@ import org.junit.runner.notification.RunNotifier
 class KotestRunnerAndroid(
   private val kClass: Class<out Spec>
 ) : Runner() {
-  private val formatter = DefaultDisplayNameFormatter(ProjectConfiguration())
+  private val formatter = DefaultDisplayNameFormatter()
 
   override fun run(notifier: RunNotifier) {
     runBlocking {
@@ -25,9 +27,10 @@ class KotestRunnerAndroid(
   }
 
   override fun getDescription(): Description {
-    val spec = runBlocking { createAndInitializeSpec(kClass.kotlin, EmptyExtensionRegistry).getOrThrow() }
+    val spec = runBlocking { SpecInstantiator(EmptyExtensionRegistry, ProjectConfigResolver()).createAndInitializeSpec( kClass.kotlin).getOrThrow() }
+    spec.duplicateTestNameMode = DuplicateTestNameMode.Warn
     val desc = Description.createSuiteDescription(spec::class.java)
-    Materializer(ProjectConfiguration()).materialize(spec).forEach { rootTest ->
+    Materializer().materialize(spec).forEach { rootTest ->
       desc.addChild(
         describeTestCase(
           rootTest,


### PR DESCRIPTION
This PR fixes incompatibilities with Kotest 6.0.0.M4 and Kotlin 2.1.20. It includes the following updates:

* Gradle 8.14
* Kotlin 2.1.20
* Kotest 6.0.0.M4
* Dokka 1.9.10

Verified only against [Signum](https://github.com/a-sit-plus/signum) due to lack of GH-actions-based CI. resolves #31 and #36 