### PR TITLE
Kotest6 stable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Here is a Kotlin example of how to use the annotation:
 
 ```kotlin
 @RobolectricTest(sdk = Build.VERSION_CODES.O)
-class ContainedRobolectricRunnerMergeApiVersionTest {
+class ContainedRobolectricRunnerMergeApiVersionTest : StringSpec() {
   init {
     "Get the Build.VERSION_CODES.O" {
       Build.VERSION.SDK_INT shouldBe Build.VERSION_CODES.O

--- a/kotest-assertions-android/build.gradle.kts
+++ b/kotest-assertions-android/build.gradle.kts
@@ -45,11 +45,16 @@ android {
 
 configurations {
   androidTestImplementation.get().exclude("org.jetbrains", "annotations")
+  // Exclude mordant FFM modules that require minSdk 26+ (JVM 21+ feature not needed on Android)
+  all {
+    exclude(group = "com.github.ajalt.mordant", module = "mordant-jvm-ffm-jvm")
+    exclude(group = "com.github.ajalt.mordant", module = "mordant-jvm-ffm")
+  }
 }
 
 dependencies {
   implementation("androidx.core:core-ktx:1.10.0")
-  implementation("io.kotest:kotest-assertions-core:6.0.0.M6")
+  implementation("io.kotest:kotest-assertions-core:6.0.7")
 
   androidTestImplementation(project(":kotest-runner-android"))
   androidTestImplementation("androidx.test:runner:1.5.2")

--- a/kotest-assertions-android/src/androidTest/AndroidManifest.xml
+++ b/kotest-assertions-android/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name="br.com.colman.kotest.android.matchers.TestActivity"
+            android:exported="false" />
+    </application>
+
+</manifest>

--- a/kotest-assertions-android/src/androidTest/kotlin/br/com/colman/kotest/android/matchers/textview/TextViewMatchersTests.kt
+++ b/kotest-assertions-android/src/androidTest/kotlin/br/com/colman/kotest/android/matchers/textview/TextViewMatchersTests.kt
@@ -48,13 +48,14 @@ class TextViewMatchersTests : FreeSpec({
     val scenario = launchActivity<TestActivity>()
 
     scenario.onActivity {
-      val tv = it.findViewById<TextView>(R.id.textViewAllCaps)
+      val tvAllCaps = it.findViewById<TextView>(R.id.textViewAllCaps)
+      val tvNotAllCaps = it.findViewById<TextView>(R.id.textViewNotAllCaps)
 
-      tv.shouldBeAllCaps()
-      shouldThrow<AssertionError> { tv.shouldNotBeAllCaps() }
+      tvAllCaps.shouldBeAllCaps()
+      shouldThrow<AssertionError> { tvAllCaps.shouldNotBeAllCaps() }
 
-      tv.shouldNotBeAllCaps()
-      shouldThrow<AssertionError> { tv.shouldBeAllCaps() }
+      tvNotAllCaps.shouldNotBeAllCaps()
+      shouldThrow<AssertionError> { tvNotAllCaps.shouldBeAllCaps() }
     }
   }
 })

--- a/kotest-assertions-android/src/androidTest/res/layout/test_activity.xml
+++ b/kotest-assertions-android/src/androidTest/res/layout/test_activity.xml
@@ -3,25 +3,34 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-
     <TextView
         android:id="@+id/textView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:text="TextView" />
+        android:text="Kotest!" />
 
     <TextView
         android:id="@+id/textViewColored"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:text="TextView" />
+        android:text="TextView"
+        android:textColor="@android:color/black" />
 
     <TextView
         android:id="@+id/textViewAllCaps"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:text="TextView" />
+        android:text="TextView"
+        android:textAllCaps="true" />
+
+    <TextView
+        android:id="@+id/textViewNotAllCaps"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:text="TextView"
+        android:textAllCaps="false" />
 </LinearLayout>

--- a/kotest-extensions-android/build.gradle.kts
+++ b/kotest-extensions-android/build.gradle.kts
@@ -49,7 +49,7 @@ configurations {
 
 dependencies {
   implementation(kotlin("reflect"))
-  implementation("io.kotest:kotest-framework-engine:6.0.0.M6")
+  implementation("io.kotest:kotest-framework-engine:6.0.7")
   implementation("org.robolectric:robolectric:4.12.2")
   implementation("junit:junit:4.13.2")
   implementation("androidx.appcompat:appcompat:1.7.0")

--- a/kotest-extensions-android/kotest-extensions-android-tests/build.gradle.kts
+++ b/kotest-extensions-android/kotest-extensions-android-tests/build.gradle.kts
@@ -47,7 +47,8 @@ android {
 dependencies {
   implementation("androidx.test:core-ktx:1.5.0")
   testImplementation(project(":kotest-extensions-android"))
-  testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
+  testImplementation("io.kotest:kotest-runner-junit5:6.0.7")
+  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
   testImplementation("org.robolectric:robolectric:4.12.2")
   testImplementation("androidx.test.espresso:espresso-core:3.6.1")
   testImplementation("org.junit.vintage:junit-vintage-engine:5.11.3")

--- a/kotest-extensions-android/kotest-extensions-android-tests/src/test/kotlin/br/com/colman/kotest/android/extensions/ContainedRobolectricTest.kt
+++ b/kotest-extensions-android/kotest-extensions-android-tests/src/test/kotlin/br/com/colman/kotest/android/extensions/ContainedRobolectricTest.kt
@@ -7,10 +7,8 @@ import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import br.com.colman.kotest.TestApplication
 import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
-import io.kotest.core.coroutines.backgroundScope
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.core.test.testCoroutineScheduler
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.equals.shouldBeEqual
@@ -20,6 +18,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.robolectric.Shadows.shadowOf
 
 private class MockApplication : Application()
@@ -79,7 +78,7 @@ abstract class ContainedRobolectricRunnerMergeOverwriteTest : StringSpec({
 @RobolectricTest(sdk = Build.VERSION_CODES.O_MR1)
 class ContainedRobolectricRunnerMergeOverwriteO_MR1Test : ContainedRobolectricRunnerMergeOverwriteTest()
 
-@OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 @RobolectricTest
 class ContainedRobolectricRunnerBehaviorSpecTest : BehaviorSpec({
   Context("Get the Application defined in AndroidManifest.xml") {
@@ -96,25 +95,23 @@ class ContainedRobolectricRunnerBehaviorSpecTest : BehaviorSpec({
     }
   }
 
-  coroutineTestScope = true
-
   Context("Collect the flow in TestScope") {
     Given("Some numbers and a SharedFlow") {
       val numbers = listOf(1, 2, 3)
       val sharedFlow = MutableSharedFlow<Int>()
 
       And("Launch to collect the flow") {
-        val collectedNumbers = mutableListOf<Int>()
-        backgroundScope.launch(UnconfinedTestDispatcher(testCoroutineScheduler)) {
-          sharedFlow.collect { collectedNumbers.add(it) }
-        }
+        Then("Collected the same numbers") {
+          runTest {
+            val collectedNumbers = mutableListOf<Int>()
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+              sharedFlow.collect { collectedNumbers.add(it) }
+            }
 
-        When("Emit the numbers") {
-          numbers.forEach { launch { sharedFlow.emit(it) } }
+            numbers.forEach { launch { sharedFlow.emit(it) } }
 
-          testCoroutineScheduler.advanceUntilIdle()
+            testScheduler.advanceUntilIdle()
 
-          Then("Collected the same numbers") {
             collectedNumbers shouldBeEqual numbers
           }
         }

--- a/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/RobolectricExtension.kt
+++ b/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/RobolectricExtension.kt
@@ -1,7 +1,7 @@
 package br.com.colman.kotest.android.extensions.robolectric
 
 import android.app.Application
-import io.kotest.core.config.AbstractPackageConfig
+import io.kotest.core.extensions.ApplyExtension
 import io.kotest.core.extensions.ConstructorExtension
 import io.kotest.core.extensions.TestCaseExtension
 import io.kotest.core.spec.Spec
@@ -13,10 +13,6 @@ import java.util.WeakHashMap
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
 import kotlin.time.Duration
-
-class RoboElectricConfig: AbstractPackageConfig() {
-  override val extensions = listOf(RobolectricExtension())
-}
 
 /**
  * We override TestCaseExtension to configure the Robolectric environment because TestCase intercept
@@ -125,6 +121,9 @@ class RobolectricExtension : ConstructorExtension, TestCaseExtension {
 
 internal class KotestDefaultApplication : Application()
 
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ApplyExtension(RobolectricExtension::class)
 annotation class RobolectricTest(
   val application: KClass<out Application> = KotestDefaultApplication::class,
   val sdk: Int = -1,

--- a/kotest-runner-android/build.gradle.kts
+++ b/kotest-runner-android/build.gradle.kts
@@ -10,8 +10,8 @@ kotlin { jvmToolchain(17) }
 
 dependencies {
   api("junit:junit:4.13.2")
-  api("io.kotest:kotest-framework-engine:6.0.0.M6")
-  api("io.kotest:kotest-assertions-core:6.0.0.M6")
+  api("io.kotest:kotest-framework-engine:6.0.7")
+  api("io.kotest:kotest-assertions-core:6.0.7")
 }
 
 val sourcesJar by tasks.registering(Jar::class) {

--- a/kotest-runner-android/src/main/kotlin/br/com/colman/kotest/JUnitTestEngineListener.kt
+++ b/kotest-runner-android/src/main/kotlin/br/com/colman/kotest/JUnitTestEngineListener.kt
@@ -1,5 +1,6 @@
 package br.com.colman.kotest
 
+import io.kotest.common.KotestInternal
 import io.kotest.core.test.TestCase
 import io.kotest.engine.listener.AbstractTestEngineListener
 import io.kotest.engine.test.TestResult
@@ -9,6 +10,7 @@ import org.junit.runner.Description.createTestDescription
 import org.junit.runner.notification.Failure
 import org.junit.runner.notification.RunNotifier
 
+@OptIn(KotestInternal::class)
 class JUnitTestEngineListener(
    private val notifier: RunNotifier,
 ) : AbstractTestEngineListener() {

--- a/kotest-runner-android/src/main/kotlin/br/com/colman/kotest/KotestRunnerAndroid.kt
+++ b/kotest-runner-android/src/main/kotlin/br/com/colman/kotest/KotestRunnerAndroid.kt
@@ -1,11 +1,11 @@
 package br.com.colman.kotest
 
-import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.common.KotestInternal
 import io.kotest.core.names.DuplicateTestNameMode
-import io.kotest.engine.extensions.EmptyExtensionRegistry
 import io.kotest.core.spec.Spec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.config.ProjectConfigResolver
+import io.kotest.engine.extensions.DefaultExtensionRegistry
 import io.kotest.engine.spec.Materializer
 import io.kotest.engine.spec.SpecInstantiator
 import io.kotest.engine.test.names.DefaultDisplayNameFormatter
@@ -14,6 +14,7 @@ import org.junit.runner.Description
 import org.junit.runner.Runner
 import org.junit.runner.notification.RunNotifier
 
+@OptIn(KotestInternal::class)
 class KotestRunnerAndroid(
   private val kClass: Class<out Spec>
 ) : Runner() {
@@ -22,12 +23,15 @@ class KotestRunnerAndroid(
   override fun run(notifier: RunNotifier) {
     runBlocking {
       val listener = JUnitTestEngineListener(notifier)
-      TestEngineLauncher(listener).withClasses(kClass.kotlin).launch()
+      TestEngineLauncher()
+        .withListener(listener)
+        .withClasses(kClass.kotlin)
+        .launch()
     }
   }
 
   override fun getDescription(): Description {
-    val spec = runBlocking { SpecInstantiator(EmptyExtensionRegistry, ProjectConfigResolver()).createAndInitializeSpec( kClass.kotlin).getOrThrow() }
+    val spec = runBlocking { SpecInstantiator(DefaultExtensionRegistry(), ProjectConfigResolver()).createAndInitializeSpec(kClass.kotlin).getOrThrow() }
     spec.duplicateTestNameMode = DuplicateTestNameMode.Warn
     val desc = Description.createSuiteDescription(spec::class.java)
     Materializer().materialize(spec).forEach { rootTest ->


### PR DESCRIPTION
## Summary

This PR updates all modules to support Kotest 6 stable release (6.0.7).

### Breaking Changes in Kotest 6

- **AutoScan removal**: `AbstractPackageConfig` is no longer available. This PR uses `@ApplyExtension` as a meta-annotation on `@RobolectricTest`, so users don't need to create a `ProjectConfig`.
- **TestEngineLauncher API change**: The constructor no longer accepts a listener directly. Use the builder pattern instead: `TestEngineLauncher().withListener(listener).withClasses(...)`.
- **Internal API annotations**: Some APIs now require `@OptIn(KotestInternal::class)`.
- **Coroutine test utilities**: `io.kotest.core.coroutines.backgroundScope` has been removed. Use `kotlinx.coroutines.test.runTest` with `TestScope.backgroundScope` instead.

### Changes by Module

**kotest-runner-android**
- Updated `TestEngineLauncher` usage to builder pattern
- Changed `EmptyExtensionRegistry` to `DefaultExtensionRegistry`
- Added `@OptIn(KotestInternal::class)` annotations

**kotest-extensions-android**
- Removed `RoboElectricConfig` class (AutoScan no longer works)
- Added `@ApplyExtension(RobolectricExtension::class)` to `@RobolectricTest` annotation
- Added `@Target` and `@Retention` annotations to `RobolectricTest`

**kotest-extensions-android-tests**
- Updated to Kotest 6.0.7
- Added `kotlinx-coroutines-test` dependency
- Rewrote coroutine tests to use `runTest`

**kotest-assertions-android**
- Added `AndroidManifest.xml` for androidTest (fixes activity resolution)
- Fixed test layout to match test expectations
- Fixed `TextViewMatchersTests` AllCaps test logic
- Added mordant-jvm-ffm exclusion (requires minSdk 26+)

**README**
- Fixed example code to extend `StringSpec`

### References

- [Features and Changes in Kotest 6.0 | Kotest](https://kotest.io/docs/next/release6/)
- [Features and Changes in Kotest 6.0 #removed-classpath-scanning | Kotest](https://kotest.io/docs/next/release6/#removed-classpath-scanning) - `@ApplyExtension` usage example
