### PR TITLE
Add support for multi-SDK and additional Robolectric configurations

### DIFF
--- a/kotest-extensions-android/kotest-extensions-android-tests/src/test/kotlin/br/com/colman/kotest/android/extensions/ContainedRobolectricTest.kt
+++ b/kotest-extensions-android/kotest-extensions-android-tests/src/test/kotlin/br/com/colman/kotest/android/extensions/ContainedRobolectricTest.kt
@@ -1,6 +1,7 @@
 package br.com.colman.kotest.android.extensions
 
 import android.app.Application
+import android.content.res.Configuration
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -20,6 +21,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
 
 private class MockApplication : Application()
 
@@ -37,14 +40,14 @@ class ContainedRobolectricRunnerChangeApplicationTest : StringSpec({
   }
 })
 
-@RobolectricTest(sdk = Build.VERSION_CODES.O)
+@RobolectricTest(sdk = [Build.VERSION_CODES.O])
 class ContainedRobolectricRunnerChangeApiLevelOTest : StringSpec({
   "Get the Build.VERSION_CODES.O" {
     Build.VERSION.SDK_INT shouldBe Build.VERSION_CODES.O
   }
 })
 
-@RobolectricTest(sdk = Build.VERSION_CODES.KITKAT)
+@RobolectricTest(sdk = [Build.VERSION_CODES.KITKAT])
 class ContainedRobolectricRunnerChangeApiLevelKITKATTest : StringSpec({
   "Get the Build.VERSION_CODES.KITKAT" {
     Build.VERSION.SDK_INT shouldBe Build.VERSION_CODES.KITKAT
@@ -54,7 +57,7 @@ class ContainedRobolectricRunnerChangeApiLevelKITKATTest : StringSpec({
 @RobolectricTest(application = MockApplication::class)
 abstract class ContainedRobolectricRunnerMergeTest : StringSpec()
 
-@RobolectricTest(sdk = Build.VERSION_CODES.O)
+@RobolectricTest(sdk = [Build.VERSION_CODES.O])
 class ContainedRobolectricRunnerMergeApiVersionTest : ContainedRobolectricRunnerMergeTest() {
   init {
     "Get the Build.VERSION_CODES.O" {
@@ -67,7 +70,7 @@ class ContainedRobolectricRunnerMergeApiVersionTest : ContainedRobolectricRunner
   }
 }
 
-@RobolectricTest(application = MockApplication::class, sdk = Build.VERSION_CODES.O)
+@RobolectricTest(application = MockApplication::class, sdk = [Build.VERSION_CODES.O])
 abstract class ContainedRobolectricRunnerMergeOverwriteTest : StringSpec({
   "Get not Build.VERSION_CODES.O" {
     Build.VERSION.SDK_INT shouldNotBe Build.VERSION_CODES.O
@@ -75,8 +78,107 @@ abstract class ContainedRobolectricRunnerMergeOverwriteTest : StringSpec({
 })
 
 @Suppress("ClassName")
-@RobolectricTest(sdk = Build.VERSION_CODES.O_MR1)
+@RobolectricTest(sdk = [Build.VERSION_CODES.O_MR1])
 class ContainedRobolectricRunnerMergeOverwriteO_MR1Test : ContainedRobolectricRunnerMergeOverwriteTest()
+
+// --- multiple sdk ---
+
+@RobolectricTest(sdk = [Build.VERSION_CODES.O, Build.VERSION_CODES.P])
+class ContainedRobolectricRunnerMultipleSdkTest : StringSpec({
+  "SDK version should be one of O or P" {
+    (Build.VERSION.SDK_INT in setOf(Build.VERSION_CODES.O, Build.VERSION_CODES.P)) shouldBe true
+  }
+})
+
+// --- minSdk / maxSdk ---
+
+@RobolectricTest(minSdk = Build.VERSION_CODES.O)
+class ContainedRobolectricRunnerMinSdkTest : StringSpec({
+  "SDK version should be at least O" {
+    Build.VERSION.SDK_INT shouldBe Build.VERSION_CODES.O
+  }
+})
+
+@RobolectricTest(minSdk = Build.VERSION_CODES.O, maxSdk = Build.VERSION_CODES.P)
+class ContainedRobolectricRunnerMaxSdkTest : StringSpec({
+  "SDK version should be between O and P" {
+    (Build.VERSION.SDK_INT in Build.VERSION_CODES.O..Build.VERSION_CODES.P) shouldBe true
+  }
+})
+
+@RobolectricTest(minSdk = Build.VERSION_CODES.O, maxSdk = Build.VERSION_CODES.O)
+class ContainedRobolectricRunnerMinMaxSdkTest : StringSpec({
+  "SDK version should be exactly O when minSdk and maxSdk are both O" {
+    Build.VERSION.SDK_INT shouldBe Build.VERSION_CODES.O
+  }
+})
+
+// --- fontScale ---
+
+@RobolectricTest(fontScale = 2.0f)
+class ContainedRobolectricRunnerFontScaleTest : StringSpec({
+  "Font scale should be 2.0" {
+    val config: Configuration = ApplicationProvider.getApplicationContext<Application>().resources.configuration
+    config.fontScale shouldBe 2.0f
+  }
+})
+
+// --- qualifiers ---
+
+@RobolectricTest(qualifiers = "ko-rKR-w360dp-h640dp-ldpi")
+class ContainedRobolectricRunnerQualifiersTest : StringSpec({
+  "Qualifiers should set locale and screen configuration" {
+    val config: Configuration = ApplicationProvider.getApplicationContext<Application>().resources.configuration
+    config.densityDpi shouldBe 120 // ldpi
+  }
+})
+
+// --- shadows ---
+
+@Implements(android.util.Log::class)
+class ShadowCustomLog {
+  companion object {
+    @Implementation
+    @JvmStatic
+    fun d(tag: String?, msg: String?): Int = 42
+  }
+}
+
+@RobolectricTest(shadows = [ShadowCustomLog::class])
+class ContainedRobolectricRunnerShadowsTest : StringSpec({
+  "Custom shadow should override Log.d()" {
+    android.util.Log.d("test", "message") shouldBe 42
+  }
+})
+
+// --- instrumentedPackages ---
+
+@RobolectricTest(instrumentedPackages = ["br.com.colman.kotest.android.extensions"])
+class ContainedRobolectricRunnerInstrumentedPackagesTest : StringSpec({
+  "Instrumented packages should allow the class to be loaded by Robolectric classloader" {
+    val classLoader = this::class.java.classLoader!!
+    classLoader.javaClass.name shouldNotBe "sun.misc.Launcher\$AppClassLoader"
+  }
+})
+
+// --- inheritance merging with new properties ---
+
+@RobolectricTest(fontScale = 1.5f)
+abstract class ContainedRobolectricRunnerMergeFontScaleTest : StringSpec()
+
+@RobolectricTest(sdk = [Build.VERSION_CODES.O])
+class ContainedRobolectricRunnerMergeFontScaleAndSdkTest : ContainedRobolectricRunnerMergeFontScaleTest() {
+  init {
+    "SDK should be O" {
+      Build.VERSION.SDK_INT shouldBe Build.VERSION_CODES.O
+    }
+
+    "Font scale should be 1.5 from parent annotation" {
+      val config: Configuration = ApplicationProvider.getApplicationContext<Application>().resources.configuration
+      config.fontScale shouldBe 1.5f
+    }
+  }
+}
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RobolectricTest

--- a/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/RobolectricExtension.kt
+++ b/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/RobolectricExtension.kt
@@ -5,6 +5,7 @@ import io.kotest.core.extensions.ApplyExtension
 import io.kotest.core.extensions.ConstructorExtension
 import io.kotest.core.extensions.TestCaseExtension
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.scopes.RootScope
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.isRootTest
 import io.kotest.engine.test.TestResult
@@ -22,6 +23,7 @@ import kotlin.time.Duration
 class RobolectricExtension : ConstructorExtension, TestCaseExtension {
 
   private val runnerMap = WeakHashMap<Spec, ContainedRobolectricRunner>()
+  private val sdkRunnerMap = WeakHashMap<Spec, Map<String, ContainedRobolectricRunner>>()
 
 
   private fun Class<*>.getParentClass(): List<Class<*>> {
@@ -46,19 +48,49 @@ class RobolectricExtension : ConstructorExtension, TestCaseExtension {
         .mapNotNull { it.kotlin.findAnnotation<RobolectricTest>() }
         .asSequence()
 
+    val sdk: IntArray? =
+      robolectricTestAnnotations.firstOrNull { it.sdk.isNotEmpty() }?.sdk
+    val minSdk: Int? =
+      robolectricTestAnnotations.firstOrNull { it.minSdk != -1 }?.minSdk
+    val maxSdk: Int? =
+      robolectricTestAnnotations.firstOrNull { it.maxSdk != -1 }?.maxSdk
+    val fontScale: Float? =
+      robolectricTestAnnotations.firstOrNull { it.fontScale != -1f }?.fontScale
     val application: KClass<out Application>? =
       robolectricTestAnnotations
         .firstOrNull { it.application != KotestDefaultApplication::class }?.application
-    val sdk: Int? = robolectricTestAnnotations.firstOrNull { it.sdk != -1 }?.takeUnless { it.sdk == -1 }?.sdk
+    val qualifiers: String? =
+      robolectricTestAnnotations.firstOrNull { it.qualifiers.isNotEmpty() }?.qualifiers
+    val shadows: Array<KClass<*>>? =
+      robolectricTestAnnotations.firstOrNull { it.shadows.isNotEmpty() }?.shadows
+    val instrumentedPackages: Array<String>? =
+      robolectricTestAnnotations.firstOrNull { it.instrumentedPackages.isNotEmpty() }?.instrumentedPackages
 
     return Config.Builder()
       .also { builder ->
+        if (sdk != null) {
+          builder.setSdk(*sdk)
+        }
+        if (minSdk != null) {
+          builder.setMinSdk(minSdk)
+        }
+        if (maxSdk != null) {
+          builder.setMaxSdk(maxSdk)
+        }
+        if (fontScale != null) {
+          builder.setFontScale(fontScale)
+        }
         if (application != null) {
           builder.setApplication(application.java)
         }
-
-        if (sdk != null) {
-          builder.setSdk(sdk)
+        if (qualifiers != null) {
+          builder.setQualifiers(qualifiers)
+        }
+        if (shadows != null) {
+          builder.setShadows(*shadows.map { it.java }.toTypedArray())
+        }
+        if (instrumentedPackages != null) {
+          builder.setInstrumentedPackages(*instrumentedPackages)
         }
       }.build()
   }
@@ -66,11 +98,41 @@ class RobolectricExtension : ConstructorExtension, TestCaseExtension {
   override fun <T : Spec> instantiate(clazz: KClass<T>): Spec? {
     clazz.findAnnotation<RobolectricTest>() ?: return null
 
-    val runner = ContainedRobolectricRunner(clazz.getConfig())
+    val config = clazz.getConfig()
+    val sdks = config.sdk
 
-    val spec = runner.sdkEnvironment.bootstrappedClass<Spec>(clazz.java).newInstance()
-    runnerMap[spec] = runner
-    return spec
+    if (sdks.size <= 1) {
+      val runner = ContainedRobolectricRunner(config)
+      val spec = runner.sdkEnvironment.bootstrappedClass<Spec>(clazz.java).newInstance()
+      runnerMap[spec] = runner
+      return spec
+    }
+
+    // Multi-SDK: create a runner and spec for each SDK
+    data class SdkEntry(val sdk: Int, val runner: ContainedRobolectricRunner, val spec: Spec)
+
+    val sdkEntries = sdks.map { sdk ->
+      val singleSdkConfig = Config.Builder(config).setSdk(sdk).build()
+      val runner = ContainedRobolectricRunner(singleSdkConfig)
+      val spec = runner.sdkEnvironment.bootstrappedClass<Spec>(clazz.java).newInstance()
+      SdkEntry(sdk, runner, spec)
+    }
+
+    // First SDK uses the original test names, additional SDKs get [SDK XX] prefix
+    val primary = sdkEntries.first()
+    runnerMap[primary.spec] = primary.runner
+
+    val nameToRunner = mutableMapOf<String, ContainedRobolectricRunner>()
+    for (entry in sdkEntries.drop(1)) {
+      for (test in entry.spec.rootTests()) {
+        val prefixedName = test.name.copy(name = "[SDK ${entry.sdk}] ${test.name.name}")
+        nameToRunner[prefixedName.name] = entry.runner
+        (primary.spec as RootScope).add(test.copy(name = prefixedName))
+      }
+    }
+
+    sdkRunnerMap[primary.spec] = nameToRunner
+    return primary.spec
   }
 
   override suspend fun intercept(
@@ -107,7 +169,9 @@ class RobolectricExtension : ConstructorExtension, TestCaseExtension {
     testCase: TestCase,
     execute: suspend (TestCase) -> TestResult,
   ): TestResult {
-    val containedRobolectricRunner = runnerMap[testCase.spec]!!
+    val containedRobolectricRunner = sdkRunnerMap[testCase.spec]?.get(testCase.name.name)
+      ?: runnerMap[testCase.spec]!!
+
     if (testCase.isRootTest()) {
       containedRobolectricRunner.containedBefore()
     }
@@ -115,6 +179,7 @@ class RobolectricExtension : ConstructorExtension, TestCaseExtension {
     if (testCase.isRootTest()) {
       containedRobolectricRunner.containedAfter()
     }
+
     return result
   }
 }
@@ -125,6 +190,12 @@ internal class KotestDefaultApplication : Application()
 @Retention(AnnotationRetention.RUNTIME)
 @ApplyExtension(RobolectricExtension::class)
 annotation class RobolectricTest(
+  val sdk: IntArray = [],
+  val minSdk: Int = -1,
+  val maxSdk: Int = -1,
+  val fontScale: Float = -1f,
   val application: KClass<out Application> = KotestDefaultApplication::class,
-  val sdk: Int = -1,
+  val qualifiers: String = "",
+  val shadows: Array<KClass<*>> = [],
+  val instrumentedPackages: Array<String> = [],
 )


### PR DESCRIPTION
### Summary
This PR significantly enhances the `RobolectricExtension` by introducing support for multi-SDK testing and expanding the configuration options available via the `@RobolectricTest` annotation. These changes allow for more comprehensive Android testing directly within Kotest specs.

---

### Key Changes

* **Multi-SDK Execution**: The `sdk` parameter in `@RobolectricTest` has been updated to an `IntArray`. When multiple SDKs are specified, the extension replicates the spec's tests for each version, prefixing test names (e.g., `[SDK 26] my test`) and running them in isolated environments.
* **Expanded @RobolectricTest Options**: Added support for several Robolectric configuration properties:
    * `minSdk` and `maxSdk` for range-based version testing.
    * `fontScale` to verify UI behavior under different accessibility settings.
    * `qualifiers` for resource and screen configuration (e.g., `ko-rKR-w360dp`).
    * `shadows` to register custom Robolectric shadows.
    * `instrumentedPackages` to control class loader instrumentation.
* **Improved Configuration Merging**: Updated the annotation processing logic to correctly traverse the class hierarchy, allowing child specs to inherit or override Robolectric settings from parent classes.
* **Refined Test Routing**: Implemented `sdkRunnerMap` to ensure that SDK-prefixed tests are correctly routed to their respective `ContainedRobolectricRunner` instances.