### PR TITLE
⬆️ Bump Kotest to 6.2.2

### DIFF
--- a/kotest-assertions-android/build.gradle.kts
+++ b/kotest-assertions-android/build.gradle.kts
@@ -58,7 +58,7 @@ configurations {
 
 dependencies {
   implementation("androidx.core:core-ktx:1.10.0")
-  implementation("io.kotest:kotest-assertions-core:6.0.7")
+  implementation("io.kotest:kotest-assertions-core:6.2.2")
 
   androidTestImplementation(project(":kotest-runner-android"))
   androidTestImplementation("androidx.test:runner:1.5.2")

--- a/kotest-extensions-android/build.gradle.kts
+++ b/kotest-extensions-android/build.gradle.kts
@@ -53,7 +53,7 @@ configurations {
 
 dependencies {
   implementation(kotlin("reflect"))
-  implementation("io.kotest:kotest-framework-engine:6.0.7")
+  implementation("io.kotest:kotest-framework-engine:6.2.2")
   implementation("org.robolectric:robolectric:4.12.2")
   implementation("junit:junit:4.13.2")
   implementation("androidx.appcompat:appcompat:1.7.0")

--- a/kotest-extensions-android/kotest-extensions-android-tests/build.gradle.kts
+++ b/kotest-extensions-android/kotest-extensions-android-tests/build.gradle.kts
@@ -47,7 +47,7 @@ android {
 dependencies {
   implementation("androidx.test:core-ktx:1.5.0")
   testImplementation(project(":kotest-extensions-android"))
-  testImplementation("io.kotest:kotest-runner-junit5:6.0.7")
+  testImplementation("io.kotest:kotest-runner-junit5:6.2.2")
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
   testImplementation("org.robolectric:robolectric:4.12.2")
   testImplementation("androidx.test.espresso:espresso-core:3.6.1")

--- a/kotest-runner-android/build.gradle.kts
+++ b/kotest-runner-android/build.gradle.kts
@@ -14,8 +14,8 @@ version = "1.2.2"
 
 dependencies {
   api("junit:junit:4.13.2")
-  api("io.kotest:kotest-framework-engine:6.0.7")
-  api("io.kotest:kotest-assertions-core:6.0.7")
+  api("io.kotest:kotest-framework-engine:6.2.2")
+  api("io.kotest:kotest-assertions-core:6.2.2")
 }
 
 val sourcesJar by tasks.registering(Jar::class) {

--- a/kotest-runner-android/src/main/kotlin/br/com/colman/kotest/KotestRunnerAndroid.kt
+++ b/kotest-runner-android/src/main/kotlin/br/com/colman/kotest/KotestRunnerAndroid.kt
@@ -3,6 +3,7 @@ package br.com.colman.kotest
 import io.kotest.common.KotestInternal
 import io.kotest.core.names.DuplicateTestNameMode
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.config.ProjectConfigResolver
 import io.kotest.engine.extensions.DefaultExtensionRegistry
@@ -19,14 +20,15 @@ class KotestRunnerAndroid(
   private val kClass: Class<out Spec>
 ) : Runner() {
   private val formatter = DefaultDisplayNameFormatter()
+  private val specRef = SpecRef.Reference(kClass.kotlin)
 
   override fun run(notifier: RunNotifier) {
     runBlocking {
       val listener = JUnitTestEngineListener(notifier)
       TestEngineLauncher()
         .withListener(listener)
-        .withClasses(kClass.kotlin)
-        .launch()
+        .withSpecRefs(specRef)
+        .execute()
     }
   }
 
@@ -34,7 +36,7 @@ class KotestRunnerAndroid(
     val spec = runBlocking { SpecInstantiator(DefaultExtensionRegistry(), ProjectConfigResolver()).createAndInitializeSpec(kClass.kotlin).getOrThrow() }
     spec.duplicateTestNameMode = DuplicateTestNameMode.Warn
     val desc = Description.createSuiteDescription(spec::class.java)
-    Materializer().materialize(spec).forEach { rootTest ->
+    Materializer().materialize(spec, specRef).forEach { rootTest ->
       desc.addChild(
         describeTestCase(
           rootTest,


### PR DESCRIPTION
Bumps Kotest from `6.0.7` to `6.2.2` across all modules.

## Breaking changes handled

The engine API changed, breaking `KotestRunnerAndroid`:

- `TestEngineLauncher.withClasses(KClass)` → `withSpecRefs(SpecRef)`
- `TestEngineLauncher.launch()` → `execute()`
- `Materializer.materialize(spec)` now also requires the `SpecRef`

The `SpecRef.Reference` is built once and shared by `run()` and `getDescription()`.

## Verification

- **Robolectric extension** (`kotest-extensions-android`): 11/11 unit tests pass, on both `testDebugUnitTest` and `testReleaseUnitTest`. Covers application override, SDK level override, config merge/overwrite through inheritance, coroutines and `Handler`/`Looper` shadows.
- **Instrumented runner** (`kotest-runner-android`): ran on an API 36 emulator. 5 tests pass and the intentionally-failing spec still fails with the correct assertion message — so spec discovery, nested contexts, activity launch and failure reporting all still work.

## Notes

Two pre-existing issues surfaced while testing, both unrelated to this bump and left untouched:

- `connectedAndroidTest` crashes in AGP's Unified Test Platform (`IllegalAccessError` in the launcher's protobuf) before running anything, reporting an empty suite as a failure. Workaround used to run the instrumented tests: `-Pandroid.experimental.androidTest.useUnifiedTestPlatform=false`.
- `:kotest-extensions-android:assembleDebugAndroidTest` fails because `appcompat:1.7.0` / `core:1.13.0` require `compileSdk 34` while the module is on 33 (AGP 7.4.2 does not support 34). Reproduces on a clean `main`.

Both would be fixed by an AGP upgrade, which belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)