### PR TITLE
✅ Add regression tests for isolation modes (#35)

### DIFF
--- a/kotest-extensions-android/kotest-extensions-android-tests/src/test/kotlin/br/com/colman/kotest/android/extensions/IsolationModeRobolectricTest.kt
+++ b/kotest-extensions-android/kotest-extensions-android-tests/src/test/kotlin/br/com/colman/kotest/android/extensions/IsolationModeRobolectricTest.kt
@@ -1,0 +1,89 @@
+package br.com.colman.kotest.android.extensions
+
+import android.app.Application
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import br.com.colman.kotest.TestApplication
+import br.com.colman.kotest.android.extensions.robolectric.RobolectricTest
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression tests for https://github.com/LeoColman/kotest-android/issues/35, where every test but
+ * the first one failed whenever the isolation mode was not SingleInstance.
+ *
+ * Each spec asserts that Robolectric is alive in *every* test, and the `timesUsed` counter asserts
+ * the isolation mode is really in effect: under SingleInstance it would keep incrementing, so a
+ * regression that silently ignores the isolation mode fails these tests too.
+ */
+@RobolectricTest(sdk = Build.VERSION_CODES.O)
+class InstancePerLeafRobolectricTest : StringSpec() {
+  override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+  private var timesUsed = 0
+
+  init {
+    "First test has a Robolectric environment" { useRobolectric() }
+    "Second test has a Robolectric environment" { useRobolectric() }
+    "Third test has a Robolectric environment" { useRobolectric() }
+  }
+
+  private fun useRobolectric() {
+    timesUsed++
+    timesUsed shouldBe 1 // a fresh spec per leaf, so this test is the first user of this instance
+    ApplicationProvider.getApplicationContext<Application>()::class shouldBe TestApplication::class
+    Build.VERSION.SDK_INT shouldBe Build.VERSION_CODES.O
+  }
+}
+
+@RobolectricTest
+class InstancePerLeafNestedRobolectricTest : BehaviorSpec() {
+  override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+  private var timesUsed = 0
+
+  init {
+    Given("A Robolectric environment") {
+      When("The first branch runs") {
+        Then("The first leaf has an application context") { useRobolectric() }
+        Then("A sibling leaf also has an application context") { useRobolectric() }
+      }
+
+      When("A second branch runs") {
+        Then("Its leaf also has an application context") { useRobolectric() }
+      }
+    }
+  }
+
+  private fun useRobolectric() {
+    timesUsed++
+    timesUsed shouldBe 1
+    ApplicationProvider.getApplicationContext<Application>()::class shouldBe TestApplication::class
+  }
+}
+
+@RobolectricTest
+class InstancePerRootRobolectricTest : BehaviorSpec() {
+  override fun isolationMode() = IsolationMode.InstancePerRoot
+
+  private var timesUsed = 0
+
+  init {
+    Given("The first root") {
+      Then("Its first leaf has an application context") { useRobolectric(expectedTimesUsed = 1) }
+      Then("Its second leaf shares the root's spec instance") { useRobolectric(expectedTimesUsed = 2) }
+    }
+
+    Given("The second root") {
+      Then("It runs in a fresh spec instance") { useRobolectric(expectedTimesUsed = 1) }
+    }
+  }
+
+  private fun useRobolectric(expectedTimesUsed: Int) {
+    timesUsed++
+    timesUsed shouldBe expectedTimesUsed // a fresh spec per root, shared by the leaves under it
+    ApplicationProvider.getApplicationContext<Application>()::class shouldBe TestApplication::class
+  }
+}


### PR DESCRIPTION
Closes #35.

## TL;DR

The bug no longer reproduces — I could not make it fail on `main` (Kotest 6.0.7) or on Kotest 6.2.2. This PR adds the regression tests that pin the behaviour down so it cannot come back silently.

## Why it is fixed

The issue reported a `NullPointerException` at `runnerMap[testCase.spec]!!` for every test after the first one, whenever `isolationMode` was not `SingleInstance`.

Kotest 6 creates every fresh spec instance through `SpecRefInflator.inflate()` → `SpecInstantiator.createAndInitializeSpec()` → `ConstructorExtension.instantiate()`. That last call is our `RobolectricExtension.instantiate()`, so each new instance gets its own `ContainedRobolectricRunner` registered in `runnerMap`, and the lookup in `intercept` always finds one. Under Kotest 5, the instances created for isolation modes bypassed `ConstructorExtension`, so the map had no entry for them — hence the NPE.

In other words, the Kotest 6 upgrade (#47) fixed this, but nothing was locking it in.

## The tests

Three specs, all annotated `@RobolectricTest`:

- `InstancePerLeafRobolectricTest` — `InstancePerLeaf` on a flat `StringSpec`
- `InstancePerLeafNestedRobolectricTest` — `InstancePerLeaf` on a nested `BehaviorSpec` (the exact shape the issue pointed at)
- `InstancePerRootRobolectricTest` — `InstancePerRoot`, where leaves under a root share an instance

Each test asserts Robolectric is really alive (application context, and SDK level where configured) rather than just that the test ran — that is the actual regression: only the first test used to get an Android environment.

The `timesUsed` counter in each spec pins the isolation mode itself. Under `InstancePerLeaf` every leaf gets a fresh instance, so the counter is always 1; under `InstancePerRoot` the leaves of a root share it, so it counts 1, 2. I verified the negative control: flipping a spec to `SingleInstance` makes the counter run 1, 2, 3 and the tests fail. So a future regression that silently ignores the isolation mode is caught too, not just the NPE.

## Verification

Full extensions suite: 20 tests, 0 failures — on both `main` (Kotest 6.0.7) and the 6.2.2 branch (#50), so this PR is independent of that one and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)