### PR TITLE
Fix release build: rootTests() typo, sdk array literal, stale versions

### DIFF
--- a/kotest-assertions-android/build.gradle.kts
+++ b/kotest-assertions-android/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 kotlin { jvmToolchain(11) }
 
 group = "br.com.colman"
-version = "1.1.4"
+version = "1.1.5"
 
 android {
   namespace = "br.com.colman.kotest.assertions"

--- a/kotest-extensions-android/build.gradle.kts
+++ b/kotest-extensions-android/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 kotlin { jvmToolchain(11) }
 
 group = "br.com.colman"
-version = "0.1.9"
+version = "0.1.10"
 
 android {
   namespace = "br.com.colman.kotest.extensions"

--- a/kotest-extensions-android/kotest-extensions-android-tests/src/test/kotlin/br/com/colman/kotest/android/extensions/IsolationModeRobolectricTest.kt
+++ b/kotest-extensions-android/kotest-extensions-android-tests/src/test/kotlin/br/com/colman/kotest/android/extensions/IsolationModeRobolectricTest.kt
@@ -18,7 +18,7 @@ import io.kotest.matchers.shouldBe
  * the isolation mode is really in effect: under SingleInstance it would keep incrementing, so a
  * regression that silently ignores the isolation mode fails these tests too.
  */
-@RobolectricTest(sdk = Build.VERSION_CODES.O)
+@RobolectricTest(sdk = [Build.VERSION_CODES.O])
 class InstancePerLeafRobolectricTest : StringSpec() {
   override fun isolationMode() = IsolationMode.InstancePerLeaf
 

--- a/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/RobolectricExtension.kt
+++ b/kotest-extensions-android/src/main/kotlin/br/com/colman/kotest/android/extensions/robolectric/RobolectricExtension.kt
@@ -1,3 +1,5 @@
+@file:OptIn(io.kotest.common.KotestInternal::class)
+
 package br.com.colman.kotest.android.extensions.robolectric
 
 import android.app.Application
@@ -124,7 +126,7 @@ class RobolectricExtension : ConstructorExtension, TestCaseExtension {
 
     val nameToRunner = mutableMapOf<String, ContainedRobolectricRunner>()
     for (entry in sdkEntries.drop(1)) {
-      for (test in entry.spec.rootTests()) {
+      for (test in entry.spec.tests()) {
         val prefixedName = test.name.copy(name = "[SDK ${entry.sdk}] ${test.name.name}")
         nameToRunner[prefixedName.name] = entry.runner
         (primary.spec as RootScope).add(test.copy(name = prefixedName))

--- a/kotest-runner-android/build.gradle.kts
+++ b/kotest-runner-android/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin { jvmToolchain(17) }
 
 
 group = "br.com.colman"
-version = "1.2.2"
+version = "1.2.3"
 
 dependencies {
   api("junit:junit:4.13.2")


### PR DESCRIPTION
## Summary
`main` has failed release every push since the multi-SDK Robolectric PR merged. Two independent bugs stacked:

- **Stale versions**: `kotest-runner-android` (1.2.2), `kotest-extensions-android` (0.1.9), `kotest-assertions-android` (1.1.4) already exist on Maven Central — `nmcpPublishAggregationToCentralPortal` rejects re-publishing an existing version. No commit since the last successful release bumped them. Bumped to 1.2.3 / 0.1.10 / 1.1.5.
- **Compile error**: `RobolectricExtension.kt:127` called `entry.spec.rootTests()`, which doesn't exist on Kotest 6.2.2's `Spec` — the real method is `tests()`. That call (plus `RootScope.add`) is `@KotestInternal`, so added `@file:OptIn`. The same multi-SDK PR changed `RobolectricTest.sdk` from `Int` to `IntArray`, which broke the #35 regression test (`IsolationModeRobolectricTest.kt`) — fixed the annotation call to use array syntax.

## Test plan
- [x] `:kotest-extensions-android:compileReleaseKotlin` — compiles clean (JDK 17)
- [x] `:kotest-extensions-android:kotest-extensions-android-tests:testDebugUnitTest` — all Robolectric extension tests pass, including multi-SDK and #35 regression tests
- [x] `./gradlew build` — full build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)